### PR TITLE
Allow relative aliases

### DIFF
--- a/EditableColumn.php
+++ b/EditableColumn.php
@@ -8,7 +8,7 @@
  * @version 1.0.0
 */
 
-Yii::import('editable.EditableField');
+Yii::import('EditableField');
 Yii::import('zii.widgets.grid.CDataColumn');
 
 /**

--- a/EditableColumn.php
+++ b/EditableColumn.php
@@ -8,7 +8,7 @@
  * @version 1.0.0
 */
 
-Yii::import('EditableField');
+require_once 'EditableField.php';
 Yii::import('zii.widgets.grid.CDataColumn');
 
 /**

--- a/EditableDetailView.php
+++ b/EditableDetailView.php
@@ -8,7 +8,7 @@
  * @version 1.0.0
 */
  
-Yii::import('editable.EditableField');
+Yii::import('EditableField');
 Yii::import('zii.widgets.CDetailView');
 
 /**

--- a/EditableDetailView.php
+++ b/EditableDetailView.php
@@ -8,7 +8,7 @@
  * @version 1.0.0
 */
  
-Yii::import('EditableField');
+require_once 'EditableField.php';
 Yii::import('zii.widgets.CDetailView');
 
 /**

--- a/EditableField.php
+++ b/EditableField.php
@@ -480,6 +480,8 @@ class EditableField extends CWidget
         $form = yii::app()->editable->form;
         $mode = yii::app()->editable->mode;
          
+		$assetsDir = __DIR__ . DIRECTORY_SEPARATOR . 'assets' . DIRECTORY_SEPARATOR;
+		
         // bootstrap
         if($form === EditableConfig::FORM_BOOTSTRAP) {
             if (($bootstrap = yii::app()->getComponent('bootstrap'))) {
@@ -489,7 +491,7 @@ class EditableField extends CWidget
                 throw new CException('You need to setup Yii-bootstrap extension first.');
             }
             
-            $assetsUrl = $am->publish(Yii::getPathOfAlias('editable.assets.bootstrap-editable')); 
+            $assetsUrl = $am->publish($assetsDir . 'bootstrap-editable');
             $js = $mode === EditableConfig::POPUP ? 'bootstrap-editable.js' : 'bootstrap-editable-inline.js';
             $css = 'bootstrap-editable.css';
         // jqueryui
@@ -501,12 +503,12 @@ class EditableField extends CWidget
             //register jquery ui
             $this->registerJQueryUI();
             
-            $assetsUrl = $am->publish(Yii::getPathOfAlias('editable.assets.jqueryui-editable')); 
+            $assetsUrl = $am->publish($assetsDir . 'jqueryui-editable'); 
             $js = $mode === EditableConfig::POPUP ? 'jqueryui-editable.js' : 'jqueryui-editable-inline.js';
             $css = 'jqueryui-editable.css';
         // plain jQuery
         } else {
-            $assetsUrl = $am->publish(Yii::getPathOfAlias('editable.assets.jquery-editable')); 
+            $assetsUrl = $am->publish($assetsDir . 'jquery-editable'); 
             $js = $mode === EditableConfig::POPUP ? 'jquery-editable-poshytip.js' : 'jquery-editable-inline.js';
             $css = 'jquery-editable.css';             
             

--- a/EditableField.php
+++ b/EditableField.php
@@ -480,8 +480,8 @@ class EditableField extends CWidget
         $form = yii::app()->editable->form;
         $mode = yii::app()->editable->mode;
          
-		$assetsDir = __DIR__ . DIRECTORY_SEPARATOR . 'assets' . DIRECTORY_SEPARATOR;
-		
+        $assetsDir = __DIR__ . DIRECTORY_SEPARATOR . 'assets' . DIRECTORY_SEPARATOR;
+
         // bootstrap
         if($form === EditableConfig::FORM_BOOTSTRAP) {
             if (($bootstrap = yii::app()->getComponent('bootstrap'))) {


### PR DESCRIPTION
Because the current configuration was very restrictive, i.e.: forcing you to
place a Yii::import() call in the configuration file, instead if being
able to use 'import' or 'components' with fully specified class path, i've
made some modifications to allow this.
