### PR TITLE
Correct errors

### DIFF
--- a/EditableField.php
+++ b/EditableField.php
@@ -111,7 +111,10 @@ class EditableField extends Editable
         
         //set value directly for autotext generation
         if($this->_prepareToAutotext) {
-            $this->value = $this->model->getAttribute($this->attribute); 
+            $this->value = $this->model->{($this->attribute)};
+            if(is_array($this->value) ){
+                $this->value = implode(',', $this->value);
+            }
         }
         
         //generate title from attribute label

--- a/EditableSaver.php
+++ b/EditableSaver.php
@@ -148,7 +148,19 @@ class EditableSaver extends CComponent
         $this->checkErrors();
 
         //saving (no validation, only changed attributes)
-        if ($this->model->save(false, $this->changedAttributes)) {
+        $attibuteNames = $this->model->attributeNames();
+        if( array_search($this->changedAttributes, $attibuteNames) == false )
+        {
+            //save any field couse another way it gives error 
+            //in line 290 throw new CDbException(Yii::t('yii','No columns are being updated for table "{table}".', 
+            //in class CDbCommandBuilder
+            $atrName = $attibuteNames[0];
+        }
+        else 
+        {
+        	$atrName = $this->changedAttributes;
+        }
+        if ($this->model->save(false, $atrName)) {
             //trigger afterUpdate event
             $this->afterUpdate();
         } else {

--- a/EditableSaver.php
+++ b/EditableSaver.php
@@ -148,19 +148,25 @@ class EditableSaver extends CComponent
         $this->checkErrors();
 
         //saving (no validation, only changed attributes)
+        //delete attributes which in DB table schema
         $attibuteNames = $this->model->attributeNames();
-        if( array_search($this->changedAttributes, $attibuteNames) == false )
+        $changedAttributes = $this->changedAttributes;
+        foreach ($changedAttributes as $key=>$val)
         {
-            //save any field couse another way it gives error 
-            //in line 290 throw new CDbException(Yii::t('yii','No columns are being updated for table "{table}".', 
-            //in class CDbCommandBuilder
-            $atrName = $attibuteNames[0];
+            if( array_search($val, $attibuteNames) == false )
+        	{
+        		unset($changedAttributes[$key]);
+        	}
         }
-        else 
+        if( count($changedAttributes) == 0 )
         {
-        	$atrName = $this->changedAttributes;
+        	//save any field couse another way it gives error
+        	//in line 290 throw new CDbException(Yii::t('yii','No columns are being updated for table "{table}".',
+        	//in class CDbCommandBuilder
+        	$changedAttributes[] = $attibuteNames[0];
         }
-        if ($this->model->save(false, $atrName)) {
+        
+        if ($this->model->save(false, $changedAttributes)) {
             //trigger afterUpdate event
             $this->afterUpdate();
         } else {


### PR DESCRIPTION
I create a model with relations 'childObjects' MANY_MANY .
To edit this model i add field 'childObjectsIds' and in action 'beforeSave' i modify 'childObjects'.

With standart forms it`s work, but now i get error:

if($fields===array())
throw new CDbException(Yii::t('yii','No columns are being updated for table "{table}".',

in CDbCommandBuilder on 290 line.
