### PR TITLE
add additional data for source link urls with dynamic data

### DIFF
--- a/Editable.php
+++ b/Editable.php
@@ -35,6 +35,10 @@ class Editable extends CWidget
     */
     public $pk = null; 
     /**
+    * @var array additional data to send to server via get to source url requets
+    */
+    public $additional_data=null;
+    /**
     * @var string name of field
     * @see x-editable
     */
@@ -327,6 +331,15 @@ class Editable extends CWidget
         //set data-pk 
         if($this->pk !== null) {
            $htmlOptions['data-pk'] = is_array($this->pk) ? CJSON::encode($this->pk) : $this->pk; 
+        }
+
+        // set additional_data
+        if($this->additional_data && is_array($this->additional_data))
+        {
+            foreach($this->additional_data as $data_key => $data_value)    
+            {
+                $htmlOptions['data-'.$data_key] = is_array($data_value) ? CJSON::encode($data_value) : $data_value;
+            }
         }
 
         //if input type assumes autotext (e.g. select) we define value directly in data-value 

--- a/EditableColumn.php
+++ b/EditableColumn.php
@@ -82,6 +82,15 @@ class EditableColumn extends CDataColumn
         //apply may be a string expression, see https://github.com/vitalets/x-editable-yii/issues/33
         if (isset($options['apply']) && is_string($options['apply'])) {
             $options['apply'] = $this->evaluateExpression($options['apply'], array('data'=>$data, 'row'=>$row));
+        }
+
+        // add additional data for source link requests
+        if (isset($options['additional_data']) && is_array($options['additional_data'])) {
+            foreach($options['additional_data'] as $data_key => $data_value_expression)
+            {
+                if(is_string($data_value_expression))
+                    $options['additional_data'][$data_key] = $this->evaluateExpression($data_value_expression, array('data'=>$data, 'row'=>$row));
+            }
         }           
         
         $this->grid->controller->widget($widgetClass, $options);


### PR DESCRIPTION
with this you have at least the option to add additonal data discussed https://github.com/vitalets/x-editable-yii/issues/40

e.g. by adding options like below

```
'additional_data' => array(
   'project_status_id' => '$data->project_status_id', 
   'version' => '$data->version',
   'test'=>'array($data->version,$data->project_status_id)',
),
```

then you have the possibility to access them in the source js code with e.g. $(this).data.version 

```
'source'    => 'js: function() {
                     var status_id=$(this).data().value;
                     var version=$(this).data().version;
                     var pk=$(this).data().pk;
                     return "?r=projectdetails/getProjectStatusList&status_id="+status_id+"&pk="+pk+"&version="+version;
            }',
```

the next step would be to automate the generation of the source url somehow.
