### PR TITLE
Use Bootstrap's config if using a custom JS / CSS setup

### DIFF
--- a/Editable.php
+++ b/Editable.php
@@ -548,8 +548,14 @@ class Editable extends CWidget
         // bootstrap
         }elseif($form === EditableConfig::FORM_BOOTSTRAP) {
             if (($bootstrap = yii::app()->getComponent('bootstrap'))) {
-                $bootstrap->registerCoreCss();
-                $bootstrap->registerCoreScripts();
+
+                // support Bootstrap component's internal config if someone wanted to turn things off
+                if ($bootstrap->coreCss !== false) {
+                    $bootstrap->registerCoreCss();
+                }
+                if ($bootstrap->enableJS !== false) {
+                    $bootstrap->registerCoreScripts();
+                }
             } else {
                 throw new CException('You need to setup Yii-bootstrap extension first.');
             }


### PR DESCRIPTION
I'm using a custom config in the Bootstrap component for a client (for historical reasons) and needed these settings to be honored.  Editable was loading things I had specifically turned off ;-)
