### PR TITLE
new form style when it is assumed that bootstrap is registered manually

### DIFF
--- a/Editable.php
+++ b/Editable.php
@@ -563,6 +563,12 @@ class Editable extends CWidget
             $assetsUrl = $am->publish(Yii::getPathOfAlias('editable.assets.bootstrap-editable'));
             $js = 'bootstrap-editable.js';
             $css = 'bootstrap-editable.css';
+        // presume-bootstrap
+        }elseif($form === EditableConfig::PRESUME_BOOTSTRAP) {
+			// It is assumed that bootstrap is manually added to the page.
+            $assetsUrl = $am->publish(Yii::getPathOfAlias('editable.assets.bootstrap-editable'));
+            $js = 'bootstrap-editable.js';
+            $css = 'bootstrap-editable.css';
         // jqueryui
         } elseif($form === EditableConfig::FORM_JQUERYUI) {
             if($mode === EditableConfig::POPUP && Yii::getVersion() < '1.1.13' ) {

--- a/EditableConfig.php
+++ b/EditableConfig.php
@@ -13,6 +13,7 @@ class EditableConfig extends CApplicationComponent
 
     const FORM_YII_BOOTSTRAP = 'yii_bootstrap';
     const FORM_BOOTSTRAP = 'bootstrap';
+    const PRESUME_BOOTSTRAP = 'presume_bootstrap';
     const FORM_JQUERYUI = 'jqueryui';
     const FORM_PLAIN = 'plain';
 


### PR DESCRIPTION
This pull request tries to add a form style for the situation described in #119 . It created a new form config "presume_bootstrap" which assumes that boostrap is added manually.
